### PR TITLE
upgrade_autoscale_group_module_version

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -41,7 +41,7 @@ module "autoscale_group" {
   for_each = local.ec2_capacity_providers
 
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.31.1"
+  version = "0.34.2"
 
   context = module.ecs_labels[each.key].context
 


### PR DESCRIPTION
Upgrade autoscale_group module version to avoid output error.
This error was fix in "v0.34.2" version (https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/commit/f73f2835381502618848c9255f3e700ea92cf4d5)

```
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/ecs_cluster.autoscale_group/outputs.tf line 23, in output "autoscaling_group_tags":
│   23:   value       = module.this.enabled ? aws_autoscaling_group.default[0].tags : []
│ 
│ This object has no argument, nested block, or exported attribute named "tags". Did you mean "tag"?
```