### PR TITLE
Do not overwrite "override" key in mixed_instances_policy

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -71,7 +71,7 @@ module "autoscale_group" {
   block_device_mappings      = jsondecode(jsonencode(each.value["block_device_mappings"]))
   instance_market_options    = jsondecode(jsonencode(each.value["instance_market_options"]))
   instance_refresh           = each.value["instance_refresh"]
-  mixed_instances_policy     = each.value["mixed_instances_policy"] == null ? null : merge(each.value["mixed_instances_policy"], { override = null })
+  mixed_instances_policy     = each.value["mixed_instances_policy"] == null ? null : merge({ override = null }, each.value["mixed_instances_policy"])
   placement                  = each.value["placement"]
   credit_specification       = each.value["credit_specification"]
   elastic_gpu_specifications = each.value["elastic_gpu_specifications"]


### PR DESCRIPTION
## what

Do not overwrite "override" key in mixed_instances_policy. Terraform's `merge()` function uses the last occurrence of a key in provided maps. We need to define this optional key first, to actually be able to use it.

## why

I want to be able to use this functionality and create capacity providers with multiple instance types.

## references

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group.html#mixed-instances-policy
