### PR TITLE
Enable spot instance draining when it's required

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -18,7 +18,7 @@ locals {
 echo ECS_CLUSTER="${local.cluster_name}" >> /etc/ecs/ecs.config
 echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 echo ECS_POLL_METRICS=true >> /etc/ecs/ecs.config
-echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=${provider.instance_market_options != null && provider.mixed_instances_policy != null} >> /etc/ecs/ecs.config
+echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=${provider.mixed_instances_policy != null} >> /etc/ecs/ecs.config
 echo ECS_WARM_POOLS_CHECK=${provider.warm_pool != null} >> /etc/ecs/ecs.config
 
 ${replace(provider.user_data, "#!/bin/bash", "")}


### PR DESCRIPTION
## what

instance_market_options are optional and not
needed to launch spot instances. Current behavior
can lead to sudden breaks in service and
uncontrolled loss of capacity.

## why

Using this module, one can create spot capacity but without the proper draining management. Fixing this will lead to more stable service when market options are not defined (because they don't have to be). There aren't any requirements to enable this setting though still omitting it with pure on-demand capacity providers doesn't hurt.

## references

(this has already happened to me in testing environment)
https://github.com/cloudposse/terraform-aws-ecs-cluster/issues/18
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instance-draining.html

