### PR TITLE
fix: add suffix to avoid already existing names capacity providers

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -68,16 +68,15 @@ module "autoscale_group" {
   enable_monitoring                    = each.value["enable_monitoring"]
   ebs_optimized                        = each.value["ebs_optimized"]
   ## Workaround to solve option type validation failure.
-  block_device_mappings      = jsondecode(jsonencode(each.value["block_device_mappings"]))
-  instance_market_options    = jsondecode(jsonencode(each.value["instance_market_options"]))
-  instance_refresh           = each.value["instance_refresh"]
-  mixed_instances_policy     = each.value["mixed_instances_policy"] == null ? null : merge(each.value["mixed_instances_policy"], { override = null })
-  placement                  = each.value["placement"]
-  credit_specification       = each.value["credit_specification"]
-  elastic_gpu_specifications = each.value["elastic_gpu_specifications"]
-  disable_api_termination    = each.value["disable_api_termination"]
-  max_size                   = each.value["max_size"]
-  min_size                   = each.value["min_size"]
+  block_device_mappings   = jsondecode(jsonencode(each.value["block_device_mappings"]))
+  instance_market_options = jsondecode(jsonencode(each.value["instance_market_options"]))
+  instance_refresh        = each.value["instance_refresh"]
+  mixed_instances_policy  = each.value["mixed_instances_policy"] == null ? null : merge(each.value["mixed_instances_policy"], { override = null })
+  placement               = each.value["placement"]
+  credit_specification    = each.value["credit_specification"]
+  disable_api_termination = each.value["disable_api_termination"]
+  max_size                = each.value["max_size"]
+  min_size                = each.value["min_size"]
   ## Desired capacity managed by ECS so by default we set it equal min_size
   desired_capacity                     = each.value["min_size"]
   default_cooldown                     = each.value["default_cooldown"]

--- a/ec2.tf
+++ b/ec2.tf
@@ -41,7 +41,7 @@ module "autoscale_group" {
   for_each = local.ec2_capacity_providers
 
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.41.0"
+  version = "0.41.1"
 
   context = module.ecs_labels[each.key].context
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -41,7 +41,7 @@ module "autoscale_group" {
   for_each = local.ec2_capacity_providers
 
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.39.0"
+  version = "0.41.0"
 
   context = module.ecs_labels[each.key].context
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,10 +17,6 @@ module "subnets" {
   context              = module.this.context
 }
 
-resource "random_pet" "suffix" {
-  length = 2
-}
-
 module "ecs_cluster" {
   source = "../.."
 
@@ -31,7 +27,7 @@ module "ecs_cluster" {
   capacity_providers_fargate_spot = true
   capacity_providers_ec2 = {
     ec2_default = {
-      name                        = "ec2-default-${random_pet.suffix.id}"
+      name                        = "ec2-default-${local.suffix}"
       instance_type               = "t3.medium"
       security_group_ids          = [module.vpc.vpc_default_security_group_id]
       subnet_ids                  = module.subnets.private_subnet_ids
@@ -54,6 +50,7 @@ module "ecs_cluster" {
 }
 
 locals {
+  suffix       = formatdate("YYYYMMDDhhmm", timestamp())
   cluster_name = var.enabled ? module.ecs_cluster.name : ""
   user_data    = <<EOT
 #!/bin/bash

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -51,7 +51,7 @@ module "ecs_cluster" {
 }
 
 locals {
-  suffix       = formatdate("YYYYMMDDhhmm", timestamp())
+  suffix       = formatdate("YYYYMMDDhhmmss", timestamp())
   cluster_name = var.enabled ? module.ecs_cluster.name : ""
   user_data    = <<EOT
 #!/bin/bash

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -72,7 +72,7 @@ data "aws_ssm_parameter" "ami" {
 module "autoscale_group" {
   count   = var.enabled ? 1 : 0
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.34.2"
+  version = "0.41.1"
 
   context = module.this.context
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,7 +30,8 @@ module "ecs_cluster" {
   capacity_providers_fargate      = true
   capacity_providers_fargate_spot = true
   capacity_providers_ec2 = {
-    "ec2_default_${random_pet.suffix.id}" = {
+    ec2_default = {
+      name                        = "ec2-default-${random_pet.suffix.id}"
       instance_type               = "t3.medium"
       security_group_ids          = [module.vpc.vpc_default_security_group_id]
       subnet_ids                  = module.subnets.private_subnet_ids
@@ -40,7 +41,7 @@ module "ecs_cluster" {
     }
   }
   external_ec2_capacity_providers = {
-    "external_ec2_default_${random_pet.suffix.id}" = {
+    external_ec2_default = {
       autoscaling_group_arn          = join("", module.autoscale_group[*].autoscaling_group_arn)
       managed_termination_protection = false
       managed_scaling_status         = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,7 +7,7 @@ module "vpc" {
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "2.3.0"
+  version              = "2.4.2"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = [module.vpc.igw_id]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,6 +17,10 @@ module "subnets" {
   context              = module.this.context
 }
 
+resource "random_pet" "suffix" {
+  length = 2
+}
+
 module "ecs_cluster" {
   source = "../.."
 
@@ -26,7 +30,7 @@ module "ecs_cluster" {
   capacity_providers_fargate      = true
   capacity_providers_fargate_spot = true
   capacity_providers_ec2 = {
-    ec2_default = {
+    "ec2_default_${random_pet.suffix.id}" = {
       instance_type               = "t3.medium"
       security_group_ids          = [module.vpc.vpc_default_security_group_id]
       subnet_ids                  = module.subnets.private_subnet_ids
@@ -36,7 +40,7 @@ module "ecs_cluster" {
     }
   }
   external_ec2_capacity_providers = {
-    external_ec2_default = {
+    "external_ec2_default_${random_pet.suffix.id}" = {
       autoscaling_group_arn          = join("", module.autoscale_group[*].autoscaling_group_arn)
       managed_termination_protection = false
       managed_scaling_status         = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -38,6 +38,7 @@ module "ecs_cluster" {
   }
   external_ec2_capacity_providers = {
     external_ec2_default = {
+      name                           = "external-ec2-default-${local.suffix}"
       autoscaling_group_arn          = join("", module.autoscale_group[*].autoscaling_group_arn)
       managed_termination_protection = false
       managed_scaling_status         = false

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,8 @@ locals {
     } : name if is_enabled
   ]
 
+  capacity_providers_enabled = var.capacity_providers_fargate || length(var.capacity_providers_ec2) > 0 || length(var.external_ec2_capacity_providers) > 0
+
   capacity_providers = distinct(concat(
     [for key, value in aws_ecs_capacity_provider.ec2 : value.name],
     [for key, value in aws_ecs_capacity_provider.external_ec2 : value.name],
@@ -63,7 +65,7 @@ resource "aws_ecs_cluster" "default" {
 }
 
 resource "aws_ecs_cluster_capacity_providers" "default" {
-  count = local.enabled && length(local.capacity_providers) > 0 ? 1 : 0
+  count = local.enabled && local.capacity_providers_enabled ? 1 : 0
 
   cluster_name = local.cluster_name
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -1,110 +1,116 @@
 package test
 
 import (
-  "os"
-  "strings"
-  "testing"
+	"os"
+	"strings"
+	"testing"
 
-  "github.com/gruntwork-io/terratest/modules/random"
-  "github.com/gruntwork-io/terratest/modules/terraform"
-  testStructure "github.com/gruntwork-io/terratest/modules/test-structure"
-  "github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	testStructure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
 )
 
 func cleanup(t *testing.T, terraformOptions *terraform.Options, tempTestFolder string) {
-  terraform.Destroy(t, terraformOptions)
-  os.RemoveAll(tempTestFolder)
+	terraform.Destroy(t, terraformOptions)
+
+	err := os.RemoveAll(tempTestFolder)
+	if err != nil {
+		t.Logf("Error removing temp folder %s: %v", tempTestFolder, err)
+	} else {
+		t.Logf("Successfully removed temp folder %s", tempTestFolder)
+	}
 }
 
 // Test the Terraform module in examples/complete using Terratest.
 func TestExamplesComplete(t *testing.T) {
-  t.Parallel()
-  randID := strings.ToLower(random.UniqueId())
-  attributes := []string{randID}
+	t.Parallel()
+	randID := strings.ToLower(random.UniqueId())
+	attributes := []string{randID}
 
-  rootFolder := "../../"
-  terraformFolderRelativeToRoot := "examples/complete"
-  varFiles := []string{"fixtures.us-east-2.tfvars"}
+	rootFolder := "../../"
+	terraformFolderRelativeToRoot := "examples/complete"
+	varFiles := []string{"fixtures.us-east-2.tfvars"}
 
-  tempTestFolder := testStructure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
+	tempTestFolder := testStructure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
 
-  terraformOptions := &terraform.Options{
-    // The path to where our Terraform code is located
-    TerraformDir: tempTestFolder,
-    Upgrade:      true,
-    // Variables to pass to our Terraform code using -var-file options
-    VarFiles: varFiles,
-    Vars: map[string]interface{}{
-      "attributes": attributes,
-      "enabled":    "true",
-    },
-  }
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: varFiles,
+		Vars: map[string]any{
+			"attributes": attributes,
+			"enabled":    "true",
+		},
+	}
 
-  // At the end of the test, run `terraform destroy` to clean up any resources that were created
-  defer cleanup(t, terraformOptions, tempTestFolder)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer cleanup(t, terraformOptions, tempTestFolder)
 
-  // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-  terraform.InitAndApply(t, terraformOptions)
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
 
-  // Run `terraform output` to get the value of an output variable
-  id := terraform.Output(t, terraformOptions, "id")
-  name := terraform.Output(t, terraformOptions, "name")
-  arn := terraform.Output(t, terraformOptions, "arn")
+	// Run `terraform output` to get the value of an output variable
+	id := terraform.Output(t, terraformOptions, "id")
+	name := terraform.Output(t, terraformOptions, "name")
+	arn := terraform.Output(t, terraformOptions, "arn")
 
-  // Verify we're getting back the outputs we expect
-  // Ensure we get the attribute included in the ID
-  assert.Equal(t, "eg-ue2-test-example-"+randID, name)
-  assert.Contains(t, id, "eg-ue2-test-example-"+randID)
-  assert.Contains(t, arn, "eg-ue2-test-example-"+randID)
+	// Verify we're getting back the outputs we expect
+	// Ensure we get the attribute included in the ID
+	assert.Equal(t, "eg-ue2-test-example-"+randID, name)
+	assert.Contains(t, id, "eg-ue2-test-example-"+randID)
+	assert.Contains(t, arn, "eg-ue2-test-example-"+randID)
 
-  // ************************************************************************
-  // This steps below are unusual, not generally part of the testing
-  // but included here as an example of testing this specific module.
-  // This module has a random number that is supposed to change
-  // only when the example changes. So we run it again to ensure
-  // it does not change.
+	// ************************************************************************
+	// This steps below are unusual, not generally part of the testing
+	// but included here as an example of testing this specific module.
+	// This module has a random number that is supposed to change
+	// only when the example changes. So we run it again to ensure
+	// it does not change.
 
-  // This will run `terraform apply` a second time and fail the test if there are any errors
-  terraform.Apply(t, terraformOptions)
+	// This will run `terraform apply` a second time and fail the test if there are any errors
+	terraform.Apply(t, terraformOptions)
 
-  id2 := terraform.Output(t, terraformOptions, "id")
-  name2 := terraform.Output(t, terraformOptions, "name")
-  arn2 := terraform.Output(t, terraformOptions, "arn")
+	id2 := terraform.Output(t, terraformOptions, "id")
+	name2 := terraform.Output(t, terraformOptions, "name")
+	arn2 := terraform.Output(t, terraformOptions, "arn")
 
-  assert.Equal(t, id, id2, "Expected `id` to be stable")
-  assert.Equal(t, name, name2, "Expected `name` to be stable")
-  assert.Equal(t, arn, arn2, "Expected `arn` to be stable")
+	assert.Equal(t, id, id2, "Expected `id` to be stable")
+	assert.Equal(t, name, name2, "Expected `name` to be stable")
+	assert.Equal(t, arn, arn2, "Expected `arn` to be stable")
 }
 
 func TestExamplesCompleteDisabled(t *testing.T) {
- t.Parallel()
- randID := strings.ToLower(random.UniqueId())
- attributes := []string{randID}
+	t.Parallel()
+	randID := strings.ToLower(random.UniqueId())
+	attributes := []string{randID}
 
- rootFolder := "../../"
- terraformFolderRelativeToRoot := "examples/complete"
- varFiles := []string{"fixtures.us-east-2.tfvars"}
+	rootFolder := "../../"
+	terraformFolderRelativeToRoot := "examples/complete"
+	varFiles := []string{"fixtures.us-east-2.tfvars"}
 
- tempTestFolder := testStructure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
+	tempTestFolder := testStructure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
 
- terraformOptions := &terraform.Options{
-   // The path to where our Terraform code is located
-   TerraformDir: tempTestFolder,
-   Upgrade:      true,
-   // Variables to pass to our Terraform code using -var-file options
-   VarFiles: varFiles,
-   Vars: map[string]interface{}{
-     "attributes": attributes,
-     "enabled":    "false",
-   },
- }
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: varFiles,
+		Vars: map[string]any{
+			"attributes": attributes,
+			"enabled":    "false",
+		},
+	}
 
- // At the end of the test, run `terraform destroy` to clean up any resources that were created
- defer cleanup(t, terraformOptions, tempTestFolder)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer cleanup(t, terraformOptions, tempTestFolder)
 
- // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
- results := terraform.InitAndApply(t, terraformOptions)
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	results := terraform.InitAndApply(t, terraformOptions)
 
- // Should complete successfully without creating or changing any resources
- assert.Contains(t, results, "Resources: 0 added, 0 changed, 0 destroyed.")
+	// Should complete successfully without creating or changing any resources
+	assert.Contains(t, results, "Resources: 0 added, 0 changed, 0 destroyed.")
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -24,7 +24,6 @@ func cleanup(t *testing.T, terraformOptions *terraform.Options, tempTestFolder s
 
 // Test the Terraform module in examples/complete using Terratest.
 func TestExamplesComplete(t *testing.T) {
-	t.Parallel()
 	randID := strings.ToLower(random.UniqueId())
 	attributes := []string{randID}
 
@@ -83,7 +82,6 @@ func TestExamplesComplete(t *testing.T) {
 }
 
 func TestExamplesCompleteDisabled(t *testing.T) {
-	t.Parallel()
 	randID := strings.ToLower(random.UniqueId())
 	attributes := []string{randID}
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,9 +117,6 @@ variable "capacity_providers_ec2" {
     credit_specification = optional(object({
       cpu_credits = string
     }))
-    elastic_gpu_specifications = optional(object({
-      type = string
-    }))
     disable_api_termination   = optional(bool, false)
     default_cooldown          = optional(number, 300)
     health_check_grace_period = optional(number, 300)


### PR DESCRIPTION
## what

- Add a unique suffix to capacity providers so it'll work for OpenTofu and Terraform pipelines

## why

- Resolve the following error:

```console
{"Time":"2025-07-11T12:04:15.677211992Z","Action":"output","Package":"github.com/cloudposse/terraform-example-module","Test":"TestExamplesCompleteDisabled","Output":"TestExamplesComplete 2025-07-11T12:04:15Z logger.go:66: \u001b[31m│\u001b[0m \u001b[0m\u001b[1m\u001b[31mError: \u001b[0m\u001b[0m\u001b[1mcreating ECS Capacity Provider (ec2_default): operation error ECS: CreateCapacityProvider, https response error StatusCode: 400, RequestID: 7af36f52-24a7-4337-b004-c693da222288, ClientException: The specified capacity provider already exists. To change the configuration of an existing capacity provider, update the capacity provider.\u001b[0m\n"}
```

## references

- [Failing Pipeline](https://github.com/cloudposse/terraform-aws-ecs-cluster/actions/runs/16219511053/job/45796462624)
