### PR TITLE
don't create instance profile if we're not using EC2

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 resource "aws_iam_instance_profile" "default" {
-  count = local.enabled ? 1 : 0
+  count = local.enabled && length(var.capacity_providers_ec2) > 0 ? 1 : 0
   name  = module.this.id
   role  = module.this.id
 }


### PR DESCRIPTION
## what

I was getting an error about IAM instance profiles when I'm only deploying Fargate instances.  I changed the creation conditional to only create the instance profile if the length of `var.capacity_providers_ec2` is greater than 0.

## why

- Fargate providers don't require EC2 instance profiles

## references

