### PR TITLE
docs: example usage of enhanced container insights mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module "ecs_cluster" {
   namespace = "eg"
   name      = "example"
 
-  container_insights_mode         = "enabled"
+  container_insights_mode         = "enhanced" # "enabled" by default if not specified, "enhanced" costs more but provides more detailed health and metrics.
   capacity_providers_fargate      = true
 }
 ```
@@ -287,7 +287,7 @@ For additional context, refer to some of these links.
 > - **Customer Workshops.** Engage with our team in weekly workshops, gaining insights and strategies to continuously improve and innovate.
 >
 > <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-cluster&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
-> 
+>
 </details>
 
 ## ✨ Contributing
@@ -330,15 +330,15 @@ Setup dependencies:
 
 To run tests:
 
-- Run all tests:  
+- Run all tests:
   ```sh
   atmos test run
   ```
-- Clean up test artifacts:  
+- Clean up test artifacts:
   ```sh
   atmos test clean
   ```
-- Explore additional test options:  
+- Explore additional test options:
   ```sh
   atmos test --help
   ```

--- a/README.yaml
+++ b/README.yaml
@@ -88,7 +88,7 @@ usage: |-
     namespace = "eg"
     name      = "example"
 
-    container_insights_mode         = "enabled"
+    container_insights_mode         = "enhanced" # "enabled" by default if not specified, "enhanced" costs more but provides more detailed health and metrics.
     capacity_providers_fargate      = true
   }
   ```

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,7 +22,7 @@ module "ecs_cluster" {
 
   context = module.this.context
 
-  container_insights_mode         = "enhanced"
+  container_insights_mode         = "enhanced" # "enabled" by default if not specified, "enhanced" costs more but provides more detailed health and metrics.
   capacity_providers_fargate      = true
   capacity_providers_fargate_spot = true
   capacity_providers_ec2 = {


### PR DESCRIPTION
Previous PR: https://github.com/cloudposse/terraform-aws-ecs-cluster/pull/75

This README update example got reverted because I didn't update the README.yaml (which is the source of truth): https://github.com/cloudposse/terraform-aws-ecs-cluster/commit/21740ae445f3557a14d4f07b12a3da5b76c28d34